### PR TITLE
feat: initial Windchill MCP connector (read-only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+WINDCHILL_BASE_URL=https://plm.example.com/Windchill/servlet/odata/v3
+WINDCHILL_API_TOKEN=REDACTED
+VERIFY_TLS=true
+HTTP_TIMEOUT_SECONDS=30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.dist/
+build/
+.eggs/
+.env
+.venv/
+venv/
+pytest_cache/
+.pytest_cache/
+.coverage
+*.log
+
+# IDE
+.vscode/
+.idea/
+

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "name": "Windchill Read API",
+  "version": "0.1.0",
+  "description": "Read-only MCP connector exposing select Windchill queries.",
+  "license": "Proprietary",
+  "author": "YOUR_NAME_OR_ORG",
+  "env": ["WINDCHILL_BASE_URL", "WINDCHILL_API_TOKEN", "VERIFY_TLS", "HTTP_TIMEOUT_SECONDS"],
+  "transport": { "type": "stdio", "command": ["python", "server.py"] },
+  "capabilities": { "tools": true, "resources": false, "prompts": false, "sampling": false }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+mcp
+requests
+pydantic
+pytest
+ruff
+typing-extensions

--- a/server.py
+++ b/server.py
@@ -1,0 +1,57 @@
+"""MCP server exposing read-only Windchill tools over stdio."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from mcp.server import Server, tool
+
+from src.config import BASE_URL
+from src.windchill_client import WindchillClient
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("windchill.server")
+
+server = Server(name="windchill-mcp", version="0.1.0")
+client = WindchillClient()
+
+
+@tool()
+def health_check() -> Dict[str, str]:
+    """Return service availability status."""
+    try:
+        return {"ok": "true", "base_url": BASE_URL}
+    except Exception as exc:  # pragma: no cover - unexpected
+        return {"ok": f"false: {exc}", "base_url": BASE_URL}
+
+
+@tool()
+def list_parts(container: str, limit: int = 20, state: str = "") -> List[Dict[str, Any]]:
+    """List parts from a container."""
+    if not container.strip():
+        raise ValueError("container is required")
+    if not isinstance(limit, int):  # type: ignore[unreachable]
+        raise ValueError("limit must be int")
+    limit = max(1, min(int(limit), 200))
+    state = state.strip()
+    logger.info(
+        "list_parts", extra={"container": container, "limit": limit, "state": state}
+    )
+    parts = client.list_parts(container, limit, state)
+    return [p.model_dump() for p in parts]
+
+
+@tool()
+def get_part(partNumber: str) -> Dict[str, Any]:
+    """Retrieve a single part by part number."""
+    if not partNumber.strip():
+        raise ValueError("partNumber is required")
+    logger.info("get_part", extra={"partNumber": partNumber})
+    part = client.get_part(partNumber)
+    return part.model_dump()
+
+
+if __name__ == "__main__":
+    print("Windchill MCP server ready (stdio).")
+    server.run_stdio()

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,17 @@
+"""Configuration values loaded from environment variables."""
+
+from __future__ import annotations
+
+import os
+
+
+def _get_bool(name: str, default: str) -> bool:
+    return os.getenv(name, default).lower() in {"1", "true", "yes"}
+
+
+BASE_URL: str = os.getenv("WINDCHILL_BASE_URL", "")
+API_TOKEN: str = os.getenv("WINDCHILL_API_TOKEN", "")
+VERIFY_TLS: bool = _get_bool("VERIFY_TLS", "true")
+HTTP_TIMEOUT: int = int(os.getenv("HTTP_TIMEOUT_SECONDS", "30"))
+
+__all__ = ["BASE_URL", "API_TOKEN", "VERIFY_TLS", "HTTP_TIMEOUT"]

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,20 @@
+"""Pydantic models used by the Windchill MCP connector."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Part(BaseModel):
+    partNumber: str
+    name: str
+    version: str
+    state: str
+    createdOn: Optional[str] = None
+    modifiedOn: Optional[str] = None
+
+
+class PartListResponse(BaseModel):
+    items: list[Part]

--- a/src/windchill_client.py
+++ b/src/windchill_client.py
@@ -1,0 +1,88 @@
+"""Minimal Windchill REST client with read-only operations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import logging
+
+import requests
+
+from .config import API_TOKEN, BASE_URL, HTTP_TIMEOUT, VERIFY_TLS
+from .models import Part
+
+logger = logging.getLogger(__name__)
+
+
+class WindchillClient:
+    """HTTP client for querying Windchill REST/OData endpoints."""
+
+    def __init__(self) -> None:
+        self.session = requests.Session()
+        self.base_url = BASE_URL.rstrip("/")
+        self.headers = {
+            "Authorization": f"Bearer {API_TOKEN}",
+            "Accept": "application/json",
+        }
+        # Rate limit hint: consider adding client-side throttling here.
+
+    def get(self, path: str, params: dict | None = None) -> Dict[str, Any]:
+        """Perform a GET request and return parsed JSON."""
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        logger.debug("GET %s", url)
+        try:
+            response = self.session.get(
+                url,
+                headers=self.headers,
+                params=params,
+                timeout=HTTP_TIMEOUT,
+                verify=VERIFY_TLS,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:  # pragma: no cover - network error path
+            snippet = response.text[:200]
+            raise RuntimeError(f"HTTP {response.status_code}: {snippet}") from exc
+        return response.json()
+
+    def list_parts(self, container: str, limit: int, state: str) -> List[Part]:
+        """List parts in a container.
+
+        Placeholder endpoint; swap with real Windchill path.
+        GET containers/{container}/parts?$top={limit}&$orderby=createdOn desc
+        + optional $filter=lifecycleState eq '{state}'
+        """
+        params = {"$top": limit, "$orderby": "createdOn desc"}
+        if state:
+            params["$filter"] = f"lifecycleState eq '{state}'"
+        path = f"containers/{container}/parts"
+        data = self.get(path, params=params)
+        items = data.get("items") or data.get("value") or []
+        parts: List[Part] = []
+        for raw in items:
+            normalized = {
+                "partNumber": raw.get("partNumber") or raw.get("number"),
+                "name": raw.get("name"),
+                "version": raw.get("version") or raw.get("iteration"),
+                "state": raw.get("state") or raw.get("lifecycleState"),
+                "createdOn": raw.get("createdOn"),
+                "modifiedOn": raw.get("modifiedOn"),
+            }
+            parts.append(Part(**normalized))
+        return parts
+
+    def get_part(self, part_number: str) -> Part:
+        """Fetch a single part by number.
+
+        Placeholder endpoint; swap with real Windchill path.
+        GET parts/{partNumber}
+        """
+        path = f"parts/{part_number}"
+        data = self.get(path, params=None)
+        normalized = {
+            "partNumber": data.get("partNumber") or data.get("number"),
+            "name": data.get("name"),
+            "version": data.get("version") or data.get("iteration"),
+            "state": data.get("state") or data.get("lifecycleState"),
+            "createdOn": data.get("createdOn"),
+            "modifiedOn": data.get("modifiedOn"),
+        }
+        return Part(**normalized)

--- a/tests/test_get_part.py
+++ b/tests/test_get_part.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from src.windchill_client import WindchillClient
+
+
+def test_get_part_not_found(monkeypatch) -> None:
+    client = WindchillClient()
+
+    def fake_get(self, path, params=None):  # type: ignore[override]
+        raise RuntimeError("HTTP 404: not found")
+
+    monkeypatch.setattr(WindchillClient, "get", fake_get)
+    with pytest.raises(RuntimeError) as exc:
+        client.get_part("MISSING")
+    assert "404" in str(exc.value)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from server import health_check
+from src.config import BASE_URL
+
+
+def test_health_check() -> None:
+    result = health_check()
+    assert result == {"ok": "true", "base_url": BASE_URL}

--- a/tests/test_list_parts.py
+++ b/tests/test_list_parts.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from src.windchill_client import WindchillClient
+
+
+def test_list_parts(monkeypatch) -> None:
+    client = WindchillClient()
+
+    def fake_get(self, path, params=None):  # type: ignore[override]
+        assert path == "containers/demo/parts"
+        assert params == {
+            "$top": 2,
+            "$orderby": "createdOn desc",
+            "$filter": "lifecycleState eq 'RELEASED'",
+        }
+        return {
+            "items": [
+                {
+                    "number": "123",
+                    "name": "Bolt",
+                    "iteration": "A",
+                    "lifecycleState": "RELEASED",
+                    "createdOn": "2024-01-01",
+                },
+                {
+                    "number": "124",
+                    "name": "Nut",
+                    "iteration": "B",
+                    "lifecycleState": "RELEASED",
+                    "createdOn": "2024-01-02",
+                },
+            ]
+        }
+
+    monkeypatch.setattr(WindchillClient, "get", fake_get)
+    parts = client.list_parts("demo", limit=2, state="RELEASED")
+    assert len(parts) == 2
+    assert parts[0].partNumber == "123"
+    assert parts[1].name == "Nut"


### PR DESCRIPTION
## Summary
- implement Windchill MCP server with health_check, list_parts, and get_part tools
- add HTTP client, pydantic models, configuration via environment, and manifest
- include tests, linting via ruff, and GitHub Actions workflow

## Testing
- `ruff check .`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c683d9a2288321905e564edc578b66